### PR TITLE
Dodaj domyślne ustawienia komunikacji w README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Program udostępnia 16 rejestrów (tablica `mbRegs`). Najważniejsze z nich:
 
 Zmiany wartości w tych rejestrach są zapisywane w pamięci EEPROM i przy kolejnym uruchomieniu odczytywane jako ustawienia domyślne.
 
+## Domyślne ustawienia komunikacji
+- Adres urządzenia Modbus: `1`
+- Format ramki: `8N1` (wartość `0` w rejestrze 1)
+- Prędkość transmisji: `9600` bps
+
+Wartości te można zmienić poprzez odpowiednie rejestry Modbus.
+
 ## Reset ustawień
 Aby przywrócić wartości domyślne, należy podczas włączania zasilania przytrzymać pin `resetPin` (D9) w stanie niskim przez co najmniej 1 s.
 


### PR DESCRIPTION
## Summary
- dodano sekcję opisującą domyślne ustawienia komunikacji Modbus w dokumentacji

## Testing
- `arduino-cli compile --fqbn arduino:avr:uno` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c40d5f168c83258d4990009f142674