### PR TITLE
Update relay control pin to PC0

### DIFF
--- a/triac_controller.ino
+++ b/triac_controller.ino
@@ -7,7 +7,7 @@
 const int triacPin = 8;        // wyjscie sterujace bramka triaka
 const int zeroCrossPin = A2;   // wejscie detekcji przejscia przez zero
 const int resetPin = 9;        // pin resetu ustawien (przycisk)
-const int relayPin = 5;        // PE3
+const int relayPin = 22;       // PC0
 
 uint16_t mbRegs[16] = {0};     // tablica rejestrow Modbus
 


### PR DESCRIPTION
## Summary
- change the relay control pin to digital 22 (PC0) to match the new hardware wiring

## Testing
- not run (arduino-cli is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d05f17f29c83258a0f5d011b304acb