### PR TITLE
Use analog pin A0 for relay output

### DIFF
--- a/triac_controller.ino
+++ b/triac_controller.ino
@@ -7,7 +7,7 @@
 const int triacPin = 8;        // wyjscie sterujace bramka triaka
 const int zeroCrossPin = A2;   // wejscie detekcji przejscia przez zero
 const int resetPin = 9;        // pin resetu ustawien (przycisk)
-const int relayPin = 5;        // PE3
+const int relayPin = A0;       // PC0 (physical pin 23 on Nano)
 
 uint16_t mbRegs[16] = {0};     // tablica rejestrow Modbus
 


### PR DESCRIPTION
## Summary
- update the relay pin definition to use A0 and document the Nano pin mapping

## Testing
- not run (requires Arduino toolchain and hardware outside this environment)


------
https://chatgpt.com/codex/tasks/task_e_68d0608b611083259f77364e53ce3596