### PR TITLE
Update relay pin reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Od wersji bieżącej sterownik posiada funkcję łagodnego narastania mocy. Przy
 - **A2** – detekcja przejścia przez zero (PCINT10)
 - **D9** – przytrzymanie w stanie niskim przez \>=1 s przy uruchamianiu zeruje ustawienia
 - **D2** – sygnał `TXEN` sterujący transceiverem RS‑485
-- **PE3** – sterowanie przekaźnikiem (wyjście)
+- **A0 / PC0 (fizyczny pin 23)** – sterowanie przekaźnikiem (wyjście)
 
 ## Rejestry Modbus
 Program udostępnia 16 rejestrów (tablica `mbRegs`). Najważniejsze z nich:


### PR DESCRIPTION
## Summary
- update the relay pin description in the connection list to point to A0 / PC0 (physical pin 23)
- confirm no other references to the old PE3 label remain in the README

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68d063e88cc083259d9b44c995fcb417